### PR TITLE
For issues #58 & #57 

### DIFF
--- a/measpy/audio.py
+++ b/measpy/audio.py
@@ -24,8 +24,8 @@ def audio_run_measurement(M,progress=True):
             M.out_device=None
 
     now = datetime.now()
-    M.date = now.strftime("%Y%m%d")
-    M.time = now.strftime("%H%M%S")
+    M.date = now.strftime("%Y-%m-%d")
+    M.time = now.strftime("%H:%M:%S")
 
     # Set the audio devices to use
     if M.out_sig!=None:

--- a/measpy/ni.py
+++ b/measpy/ni.py
@@ -37,8 +37,8 @@ def ni_run_measurement(M):
             M.out_device=system.devices[0].name
             
     now = datetime.now()
-    M.date = now.strftime("%Y%m%d")
-    M.time = now.strftime("%H%M%S")
+    M.date = now.strftime("%Y-%m-%d")
+    M.time = now.strftime("%H:%M:%S")
 
     # Insert a synchronization peak at the begining of the output signals
     if M.out_sig==None:

--- a/measpy/signal.py
+++ b/measpy/signal.py
@@ -306,9 +306,9 @@ class Signal:
         """
         return self.similar(
             values=np.sqrt(smooth(self.values**2,nperseg)),
-            desc=add_step(self.desc,'RMS smoothed on '+str(nperseg)+' data points',
+            desc=add_step(self.desc,'RMS smoothed on '+str(nperseg)+' data points'),
             cal=1.0,
-            dbfs=1.0)
+            dbfs=1.0
         )
 
     def rms(self):


### PR DESCRIPTION
If you use time to name file you need to remove the special character ":", but it is easier to do.