### PR TITLE
Bugfix/spectral bounds

### DIFF
--- a/measpy/audio.py
+++ b/measpy/audio.py
@@ -39,20 +39,20 @@ def audio_run_measurement(M,progress=True):
         effsync=False
     elif M.io_sync>0:
         if M.io_sync in M.in_map:
-            nout = M.x.shape[1]
+            nout = M.x_raw.shape[1]
             peaks = repmat(ms.picv(M.fs),nout,1).T
             zers = repmat(np.zeros(int(M.fs)),nout,1).T
-            outx = np.block([[peaks],[M.x],[zers]])
+            outx = np.block([[peaks],[M.x_raw],[zers]])
             effsync = True
             dursync=4
             indsearch=M.in_map.index(M.io_sync)
         else:
             print('io_sync channel not present in in_map, no sync is done')
-            outx=M.x
+            outx=M.x_raw
             dursync=0
             effsync=False
     else:
-        outx=M.x
+        outx=M.x_raw
         dursync=0
         effsync=False
         

--- a/measpy/measurement.py
+++ b/measpy/measurement.py
@@ -137,7 +137,7 @@ class Measurement:
         """
         if self.out_sig=='noise': # White noise output signal
             self.data[self.out_name[0]] = self.data[self.out_name[0]].similar(
-                volts=ms.noise(self.fs,self.dur,self.out_amp,self.out_sig_freqs)
+                volts=ms._noise(self.fs,self.dur,self.out_amp,self.out_sig_freqs)
             ).fade(self.out_sig_fades).add_silence(self.extrat)
 
             if self.out_map==0:

--- a/measpy/measurement.py
+++ b/measpy/measurement.py
@@ -77,11 +77,12 @@ class Measurement:
         if 'out_sig' in params:
             noise=params['out_sig']!='noise'
             logsweep=params['out_sig']!='logsweep'
+            sine=params['out_sig']!='sine'
             wa=not str(params['out_sig']).upper().endswith('.WAV')
             non=params['out_sig']!=None
             ar=type(params['out_sig'])!=np.ndarray
-            if noise&logsweep&wa&non&ar:
-                raise Exception("out_sig must but be a numpy.ndarray, 'noise', 'sweep', '*.wav' or None")
+            if noise&logsweep&sine&wa&non&ar:
+                raise Exception("out_sig must but be numpy.ndarray, 'noise', 'sweep', 'sine', '*.wav' or None")
 
         self.fs = params.setdefault("fs",44100)
         self.dur = params.setdefault("dur",2.0)
@@ -147,6 +148,14 @@ class Measurement:
                 volts=ms._log_sweep(self.fs,self.dur,self.out_amp,self.out_sig_freqs)
             ).fade(self.out_sig_fades).add_silence(self.extrat)
 
+            if self.out_map==0:
+                self.out_map=[1]
+
+        elif self.out_sig=='sine':  # Sinusoidal output signal
+            self.data[self.out_name[0]] = self.data[self.out_name[0]].similar(
+                volts=ms._sine(self.fs,self.dur,self.out_amp,self.out_sig_freqs[0])
+            ).fade(self.out_sig_fades).add_silence(self.extrat)
+        
             if self.out_map==0:
                 self.out_map=[1]
 

--- a/measpy/signal.py
+++ b/measpy/signal.py
@@ -1486,12 +1486,17 @@ class Spectral:
                 phase_to_plot = np.unwrap(phase_to_plot)
             
         else:
-            frequencies_to_plot = self.freqs
             modulus_to_plot = np.abs(self.values)
-            phase_to_plot = np.angle(self.values)
+
+            #Only keep positive values
+            valid_indices = np.where(modulus_to_plot > 0)
+
+            frequencies_to_plot = self.freqs[valid_indices]
+            modulus_to_plot = modulus_to_plot[valid_indices]
+            phase_to_plot = np.angle(self.values)[valid_indices]
             if unwrap_phase:
                 phase_to_plot = np.unwrap(phase_to_plot)
-            label = 'H'
+            label = '|H|'
 
         ax_0.plot(frequencies_to_plot,modulus_to_plot,**kwargs)
         ax_0.set_xlabel('Freq (Hz)')

--- a/measpy/signal.py
+++ b/measpy/signal.py
@@ -739,6 +739,17 @@ class Signal:
         )
 
     @classmethod
+    def sine(cls,fs=44100,dur=2.0,amp=1.0,freq=1000.0,unit='1',cal=1.0,dbfs=1.0):
+        return cls(
+            raw=_sine(fs,dur,amp,freq),
+            fs=fs,
+            unit=unit,
+            cal=cal,
+            dbfs=dbfs,
+            desc='Sine '+str(freq)+'Hz'
+        )
+
+    @classmethod
     def from_csvwav_old(cls,filename):
         """Load a signal from a pair of csv and wav files
 
@@ -2001,6 +2012,10 @@ def plot_tfe(f, H):
     plt.xlabel('Freq (Hz)')
     plt.ylabel('Arg(H)')
 
+def _sine(fs, dur, out_amp, freq):
+    leng=int(dur*fs)    
+    s = out_amp*np.sin(2*np.pi*np.linspace(0,dur,leng)*freq)
+    return(s)
 
 def smooth(in_array,l=20):
     ker = np.ones(l)/l

--- a/measpy/signal.py
+++ b/measpy/signal.py
@@ -1325,7 +1325,7 @@ class Spectral:
         return self.similar(
             w=self.nth_oct_smooth_to_weight(n,fmin=fmin,fmax=fmax),
             desc=add_step(self.desc,'1/'+str(n)+'th oct. smooth')
-        )
+        ).filterout((fmin,fmax))
 
     def nth_oct_smooth_complex(self,n,fmin=5,fmax=20000):
         """ Nth octave smoothing
@@ -1343,7 +1343,7 @@ class Spectral:
         return self.similar(
             w=self.nth_oct_smooth_to_weight_complex(n,fmin=fmin,fmax=fmax),
             desc=add_step(self.desc,'1/'+str(n)+'th oct. smooth')
-        )
+        ).filterout((fmin,fmax))
 
     def irfft(self):
         """ Compute the real inverse Fourier transform

--- a/measpy/signal.py
+++ b/measpy/signal.py
@@ -719,7 +719,7 @@ class Signal:
     @classmethod
     def noise(cls,fs=44100,dur=2.0,amp=1.0,freqs=[20.0,20000.0],unit='1',cal=1.0,dbfs=1.0):
         return cls(
-            raw=noise(fs,dur,amp,freqs),
+            raw=_noise(fs,dur,amp,freqs),
             fs=fs,
             unit=unit,
             cal=cal,
@@ -1943,7 +1943,7 @@ def _apply_fades(s,fades):
     return s
 
 
-def noise(fs, dur, out_amp, freqs):
+def _noise(fs, dur, out_amp, freqs):
     """ Create band-limited noise """
     leng = int(dur*fs)
     lengs2 = int(leng/2)
@@ -1984,7 +1984,7 @@ def tfe_welch(x, y, fs=None, nperseg=2**12,noverlap=None):
 
 
 def _log_sweep(fs, dur, out_amp, freqs):
-    """ Create log swwep """
+    """ Create log sweep """
     L = dur/np.log(freqs[1]/freqs[0])
     t = create_time(fs, dur=dur)
     s = np.sin(2*np.pi*freqs[0]*L*np.exp(t/L))


### PR DESCRIPTION
Adding corrected bounds excluding filtered frequencies when plotting spectral data without logarithmic scaling