### PR TITLE
Multichannel measurement

### DIFF
--- a/measpy/measurement.py
+++ b/measpy/measurement.py
@@ -355,6 +355,7 @@ class Measurement:
                 out_sig = None
             self.in_sig = in_sig
             self.out_sig = out_sig
+            self.filename = filename
         return self
 
     @classmethod
@@ -438,11 +439,11 @@ class Measurement:
             try:
                 self.in_range = convl1(float,task_dict['in_range'])
             except:
-                pass
+                self.in_range = None
             try:
                 self.out_range = convl1(float,task_dict['out_range'])
             except:
-                pass
+                self.out_range = None
             try:
                 self.in_iepe = convl(bool,task_dict['in_iepe'])
             except:

--- a/measpy/pico.py
+++ b/measpy/pico.py
@@ -638,7 +638,7 @@ def _ps2000_run_measurement_threaded(
             sig.dbfs = adc_to_mv([1],pico_range)[0] * 0.001
 
         #Picoscope2000 return 16bits signed integer
-        M.datatype = "i2"
+        M.data_type = "i2"
         M.to_hdf5(filename)
         if not multichannel:
             if enabledA:

--- a/measpy/signal.py
+++ b/measpy/signal.py
@@ -1273,9 +1273,8 @@ class Signal:
             outelt = Signal(raw=self.raw[:,i],
                 desc=to_list(self.desc,nc)[i]+added_str)
             for k,v in self.__dict__.items():
-                a = to_list(v,nc)[i]
                 # We ignore _index property as it is reverved for iterations
-                if (not k in('_rawvalues','desc','_index')) and (a is not None):
+                if (not k in('_rawvalues','desc','_index')) and ((a:=to_list(v,nc)[i]) is not None):
                     outelt.__dict__[k]=a
             outl.append(outelt)
         return outl


### PR DESCRIPTION
Correction de cas particulier : 
 - erreur avec unpack pour des signaux vides.
 - problème de save/reload de measurment avec 'ni' sans output.